### PR TITLE
Added conditional to support CoreOs in SSH tests

### DIFF
--- a/cloudcafe/compute/servers_api/behaviors.py
+++ b/cloudcafe/compute/servers_api/behaviors.py
@@ -540,6 +540,8 @@ class ServerBehaviors(BaseComputeBehavior):
                 linux_client import LinuxClient
             client = LinuxClient
 
+        if 'coreos' in image.metadata.get("os_distro", '').lower():
+            username = username or 'core'
         user = username or self.images_config.primary_image_default_user
         strategy = auth_strategy or self.config.instance_auth_strategy.lower()
 


### PR DESCRIPTION
This adds a conditional for the CoreOs user in the get_remote_instance_client behvaior. It is needed since the single config value used previously cannot be universally applied when running tests based off of generated image/flavor lists.